### PR TITLE
[GI/Proto] Added limit region and map area

### DIFF
--- a/gi/src/commonMain/kotlin/org/anime_game_servers/multi_proto/gi/data/scene/LimitRegionInfo.kt
+++ b/gi/src/commonMain/kotlin/org/anime_game_servers/multi_proto/gi/data/scene/LimitRegionInfo.kt
@@ -1,0 +1,11 @@
+package org.anime_game_servers.multi_proto.gi.data.scene
+
+import org.anime_game_servers.core.base.Version.GI_4_8_0
+import org.anime_game_servers.core.base.annotations.AddedIn
+import org.anime_game_servers.core.base.annotations.proto.ProtoModel
+
+@AddedIn(GI_4_8_0)
+@ProtoModel
+internal interface LimitRegionInfo {
+    var limitRegionList: List<Int>
+}

--- a/gi/src/commonMain/kotlin/org/anime_game_servers/multi_proto/gi/data/scene/PlayerEnterSceneNotify.kt
+++ b/gi/src/commonMain/kotlin/org/anime_game_servers/multi_proto/gi/data/scene/PlayerEnterSceneNotify.kt
@@ -41,4 +41,6 @@ internal interface PlayerEnterSceneNotify {
     var LAJGLCIFKCP : Int //TODO identify this field
     @AddedIn(GI_4_0_0)
     var mapLayerInfo : MapLayerInfo
+    @AddedIn(GI_4_8_0)
+    var limitRegionInfo: LimitRegionInfo
 }

--- a/gi/src/commonMain/kotlin/org/anime_game_servers/multi_proto/gi/data/scene/PlayerWorldSceneInfo.kt
+++ b/gi/src/commonMain/kotlin/org/anime_game_servers/multi_proto/gi/data/scene/PlayerWorldSceneInfo.kt
@@ -11,4 +11,6 @@ internal interface PlayerWorldSceneInfo {
     var isLocked: Boolean
     var sceneTagIdList: List<Int>
     var mapLayerInfo: MapLayerInfo
+    @AddedIn(GI_4_8_0)
+    var limitRegionInfo: LimitRegionInfo
 }

--- a/gi/src/commonMain/kotlin/org/anime_game_servers/multi_proto/gi/data/scene/SceneDataNotify.kt
+++ b/gi/src/commonMain/kotlin/org/anime_game_servers/multi_proto/gi/data/scene/SceneDataNotify.kt
@@ -13,4 +13,6 @@ internal interface SceneDataNotify {
     var sceneTagIdList : List<Int>
     @AddedIn(GI_4_0_0)
     var mapLayerInfo: MapLayerInfo
+    @AddedIn(GI_4_8_0)
+    var limitRegionInfo: LimitRegionInfo
 }

--- a/gi/src/commonMain/kotlin/org/anime_game_servers/multi_proto/gi/data/scene/map/GetMapAreaReq.kt
+++ b/gi/src/commonMain/kotlin/org/anime_game_servers/multi_proto/gi/data/scene/map/GetMapAreaReq.kt
@@ -1,0 +1,8 @@
+package org.anime_game_servers.multi_proto.gi.data.scene.map
+
+import org.anime_game_servers.core.base.annotations.proto.CommandType.REQUEST
+import org.anime_game_servers.core.base.annotations.proto.ProtoCommand
+
+@ProtoCommand(REQUEST)
+internal interface GetMapAreaReq {
+}

--- a/gi/src/commonMain/kotlin/org/anime_game_servers/multi_proto/gi/data/scene/map/GetMapAreaReq.kt
+++ b/gi/src/commonMain/kotlin/org/anime_game_servers/multi_proto/gi/data/scene/map/GetMapAreaReq.kt
@@ -1,8 +1,10 @@
 package org.anime_game_servers.multi_proto.gi.data.scene.map
 
+import org.anime_game_servers.core.base.Version.GI_2_2_0
+import org.anime_game_servers.core.base.annotations.AddedIn
 import org.anime_game_servers.core.base.annotations.proto.CommandType.REQUEST
 import org.anime_game_servers.core.base.annotations.proto.ProtoCommand
 
+@AddedIn(GI_2_2_0)
 @ProtoCommand(REQUEST)
-internal interface GetMapAreaReq {
-}
+internal interface GetMapAreaReq

--- a/gi/src/commonMain/kotlin/org/anime_game_servers/multi_proto/gi/data/scene/map/GetMapAreaRsp.kt
+++ b/gi/src/commonMain/kotlin/org/anime_game_servers/multi_proto/gi/data/scene/map/GetMapAreaRsp.kt
@@ -1,11 +1,14 @@
 package org.anime_game_servers.multi_proto.gi.data.scene.map
 
+import org.anime_game_servers.core.base.Version.GI_2_2_0
+import org.anime_game_servers.core.base.annotations.AddedIn
 import org.anime_game_servers.core.base.annotations.proto.CommandType.RESPONSE
 import org.anime_game_servers.core.base.annotations.proto.ProtoCommand
 import org.anime_game_servers.multi_proto.gi.data.general.Retcode
 
+@AddedIn(GI_2_2_0)
 @ProtoCommand(RESPONSE)
 internal interface GetMapAreaRsp {
-    var mapAreaInfoList: List<MapAreaInfo>
     var retcode: Retcode
+    var mapAreaInfoList: List<MapAreaInfo>
 }

--- a/gi/src/commonMain/kotlin/org/anime_game_servers/multi_proto/gi/data/scene/map/GetMapAreaRsp.kt
+++ b/gi/src/commonMain/kotlin/org/anime_game_servers/multi_proto/gi/data/scene/map/GetMapAreaRsp.kt
@@ -1,0 +1,11 @@
+package org.anime_game_servers.multi_proto.gi.data.scene.map
+
+import org.anime_game_servers.core.base.annotations.proto.CommandType.RESPONSE
+import org.anime_game_servers.core.base.annotations.proto.ProtoCommand
+import org.anime_game_servers.multi_proto.gi.data.general.Retcode
+
+@ProtoCommand(RESPONSE)
+internal interface GetMapAreaRsp {
+    var mapAreaInfoList: List<MapAreaInfo>
+    var retcode: Retcode
+}

--- a/gi/src/commonMain/kotlin/org/anime_game_servers/multi_proto/gi/data/scene/map/MapAreaInfo.kt
+++ b/gi/src/commonMain/kotlin/org/anime_game_servers/multi_proto/gi/data/scene/map/MapAreaInfo.kt
@@ -1,9 +1,12 @@
 package org.anime_game_servers.multi_proto.gi.data.scene.map
 
+import org.anime_game_servers.core.base.Version.GI_2_2_0
+import org.anime_game_servers.core.base.annotations.AddedIn
 import org.anime_game_servers.core.base.annotations.proto.ProtoModel
 
+@AddedIn(GI_2_2_0)
 @ProtoModel
 internal interface MapAreaInfo {
-    var mapAreaId: Int
     var isOpen: Boolean
+    var mapAreaId: Int
 }

--- a/gi/src/commonMain/kotlin/org/anime_game_servers/multi_proto/gi/data/scene/map/MapAreaInfo.kt
+++ b/gi/src/commonMain/kotlin/org/anime_game_servers/multi_proto/gi/data/scene/map/MapAreaInfo.kt
@@ -1,0 +1,9 @@
+package org.anime_game_servers.multi_proto.gi.data.scene.map
+
+import org.anime_game_servers.core.base.annotations.proto.ProtoModel
+
+@ProtoModel
+internal interface MapAreaInfo {
+    var mapAreaId: Int
+    var isOpen: Boolean
+}


### PR DESCRIPTION
- Limit region:
  - Used for 4.8 event-limited map and Tete island (the last island in Natlan resort)
  - This is similar to `OPEN_STATE_LIMIT_REGION_FRESHMEAT`, Paimon will appear and prevent you from trespassing
- Map area: this allow showing different states in the map UI